### PR TITLE
Do not load solution folder projects

### DIFF
--- a/Src/NuGetDefense/Program.cs
+++ b/Src/NuGetDefense/Program.cs
@@ -63,7 +63,7 @@ namespace NuGetDefense
 
                 if (args[0].EndsWith(".sln", StringComparison.OrdinalIgnoreCase))
                 {
-                    var projects = DotNetSolution.Load(args[0]).Projects.Select(p => p.Path).ToArray();
+                    var projects = DotNetSolution.Load(args[0]).Projects.Where(p => !p.Type.IsSolutionFolder).Select(p => p.Path).ToArray();
                     var specificFramework = !string.IsNullOrWhiteSpace(targetFramework);
                     if (specificFramework)
                     {


### PR DESCRIPTION
Do not load solution folders on the projects list to prevent issues loading them with `DotNetProject.Load()`

Fixes #58 