### PR TITLE
Bug 83 warn is turned on and vulnerability count is reset

### DIFF
--- a/Src/NuGetDefense.Lib/Scanner.cs
+++ b/Src/NuGetDefense.Lib/Scanner.cs
@@ -324,9 +324,14 @@ public class Scanner
 
             foreach (var (project, packages) in _projects)
             {
+                var projectNumberOfVulnerabilities = 0;
+
                 //TODO: Losing the right file somewhere here
                 vulnReporter.BuildVulnerabilityTextReport(vulnDict, packages, project, _settings.WarnOnly,
-                    _settings.ErrorSettings.Cvss3Threshold, out NumberOfVulnerabilities);
+                    _settings.ErrorSettings.Cvss3Threshold, out projectNumberOfVulnerabilities);
+
+                NumberOfVulnerabilities += projectNumberOfVulnerabilities;
+
                 if (_settings.VulnerabilityReports.OutputTextReport) Log.Logger.Information(vulnReporter.VulnerabilityTextReport);
                 foreach (var msBuildMessage in vulnReporter.MsBuildMessages)
                 {

--- a/Src/NuGetDefense.Lib/VulnerabilityReporter.cs
+++ b/Src/NuGetDefense.Lib/VulnerabilityReporter.cs
@@ -64,16 +64,13 @@ public class VulnerabilityReporter
         {
             var vulnerabilities = vulnerabilityDictionary[pkg.PackageUrl.ToLower()];
 
-
             logBuilder.AppendLine("*************************************");
-            warnOnly = warnOnly ||
-                       !vulnerabilities.Any(v => v.Value.CvssScore >= cvss3Threshold);
-
-            if (!warnOnly) numberOfVulns++;
             // TODO: Dependencies will need to be listed by package url when this is used.
             var dependantVulnerabilities = pkg.Dependencies.Where(dep => vulnerabilityDictionary.ContainsKey(dep));
 
-            var vulnTotalMSbuildMessage = MsBuild.Log(nuGetFile, warnOnly ? MsBuild.Category.Warning : MsBuild.Category.Error, pkg.LineNumber, pkg.LinePosition,
+            var warnForThisPackage = warnOnly && (vulnerabilities.Any(v => v.Value.CvssScore <= cvss3Threshold && v.Value.CvssScore > -1));
+
+            var vulnTotalMSbuildMessage = MsBuild.Log(nuGetFile, warnForThisPackage ? MsBuild.Category.Warning : MsBuild.Category.Error, pkg.LineNumber, pkg.LinePosition,
                 $"{vulnerabilities.Count} vulnerabilities found for {pkg.Id} @ {pkg.Version}");
 
             if (vulnerabilities.Any())
@@ -85,7 +82,7 @@ public class VulnerabilityReporter
             var dependancies = dependantVulnerabilities as string[] ?? dependantVulnerabilities.ToArray();
             if (dependancies.Any())
             {
-                var dependantVulnTotalMsBuildMessage = MsBuild.Log(nuGetFile, warnOnly ? MsBuild.Category.Warning : MsBuild.Category.Error, pkg.LineNumber, pkg.LinePosition,
+                var dependantVulnTotalMsBuildMessage = MsBuild.Log(nuGetFile, warnForThisPackage ? MsBuild.Category.Warning : MsBuild.Category.Error, pkg.LineNumber, pkg.LinePosition,
                     $"{dependancies.Count()} vulnerabilities found for dependencies of {pkg.Id} @ {pkg.Version}");
 
                 if (_separateMsBuildMessages) MsBuildMessages.Add(dependantVulnTotalMsBuildMessage);
@@ -94,10 +91,11 @@ public class VulnerabilityReporter
 
             foreach (var cve in vulnerabilities.Keys)
             {
-                warnOnly = warnOnly || vulnerabilities[cve].CvssScore <= cvss3Threshold && vulnerabilities[cve].CvssScore > -1;
-                if (!warnOnly) numberOfVulns++;
+                var warnForThisVuln = warnOnly && (vulnerabilities[cve].CvssScore <= cvss3Threshold && vulnerabilities[cve].CvssScore > -1);
 
-                var vulnMsBuildMessage = MsBuild.Log(nuGetFile, warnOnly ? MsBuild.Category.Warning : MsBuild.Category.Error, cve, pkg.LineNumber, pkg.LinePosition,
+                if (!warnForThisVuln) numberOfVulns++;
+
+                var vulnMsBuildMessage = MsBuild.Log(nuGetFile, warnForThisVuln ? MsBuild.Category.Warning : MsBuild.Category.Error, cve, pkg.LineNumber, pkg.LinePosition,
                     $"{vulnerabilities[cve].Description}");
 
                 if (_separateMsBuildMessages) MsBuildMessages.Add(vulnMsBuildMessage);
@@ -122,11 +120,11 @@ public class VulnerabilityReporter
                 vulnerabilities = vulnerabilityDictionary[dependancy];
                 foreach (var cve in vulnerabilities.Keys)
                 {
-                    warnOnly = warnOnly ||
-                               vulnerabilities[cve].CvssScore <= cvss3Threshold;
-                    if (!warnOnly) numberOfVulns++;
+                    var warnForThisDepVuln = warnOnly && (vulnerabilities[cve].CvssScore <= cvss3Threshold && vulnerabilities[cve].CvssScore > -1);
 
-                    var vulnMsBuildMessage = MsBuild.Log(nuGetFile, warnOnly ? MsBuild.Category.Warning : MsBuild.Category.Error, cve, pkg.LineNumber, pkg.LinePosition,
+                    if (!warnForThisDepVuln) numberOfVulns++;
+
+                    var vulnMsBuildMessage = MsBuild.Log(nuGetFile, warnForThisDepVuln ? MsBuild.Category.Warning : MsBuild.Category.Error, cve, pkg.LineNumber, pkg.LinePosition,
                         $"{dependancy}: {vulnerabilities[cve].Description}");
 
                     if (_separateMsBuildMessages) MsBuildMessages.Add(vulnMsBuildMessage);


### PR DESCRIPTION
Ensure the vulnerability count increments with multiple projects instead of being reset.

Don't change the value of warnOnly when using it.

Don't increment vulnerability count twice for 1 vulnerability.